### PR TITLE
v1.11.0 - Rename Spillover Stock to Stock Library

### DIFF
--- a/dist/media-library.es.js
+++ b/dist/media-library.es.js
@@ -48120,7 +48120,7 @@ const em = [
   },
   {
     key: "global",
-    name: "Spillover Stock"
+    name: "Stock Library"
   },
   {
     key: "favorites",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spillover/media-library",
-  "version": "1.10.11",
+  "version": "1.11.0",
   "description": "Media Library react component",
   "license": "UNLICENSED",
   "private": true,

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -12,7 +12,7 @@ const mediaBrowsers = [
   },
   {
     key: "global",
-    name: "Spillover Stock",
+    name: "Stock Library",
   },
   {
     key: "favorites",


### PR DESCRIPTION
Partner-neutral label: the stock browser now serves each partner's own stock library, so the Spillover branding no longer fits.